### PR TITLE
changed ajax button to say saving once pressed

### DIFF
--- a/assets/js/components/ajax-button.component.js
+++ b/assets/js/components/ajax-button.component.js
@@ -26,10 +26,7 @@ parasails.registerComponent('ajaxButton', {
     <span class="button-text" v-if="!syncing"><slot name="default">Submit</slot></span>
     <span class="button-loader clearfix" v-if="syncing">
       <slot name="syncing-state">
-        <div class="loading-dot dot1"></div>
-        <div class="loading-dot dot2"></div>
-        <div class="loading-dot dot3"></div>
-        <div class="loading-dot dot4"></div>
+        <div>Saving...</div>
       </slot>
     </span>
   </button>

--- a/assets/styles/styleguide/buttons.less
+++ b/assets/styles/styleguide/buttons.less
@@ -29,7 +29,7 @@
       display: inline-block;
     }
     .button-text {
-      display: none;
+      // display: none;
     }
   }
 }

--- a/assets/styles/styleguide/buttons.less
+++ b/assets/styles/styleguide/buttons.less
@@ -29,7 +29,7 @@
       display: inline-block;
     }
     .button-text {
-      // display: none;
+      //display: none;
     }
   }
 }

--- a/assets/styles/styleguide/buttons.less
+++ b/assets/styles/styleguide/buttons.less
@@ -29,7 +29,7 @@
       display: inline-block;
     }
     .button-text {
-      //display: none;
+      display: none;
     }
   }
 }


### PR DESCRIPTION
This was a funny one. The ajax button was actually working as it was supposed to but because it slowly fades some dots across it when its saving you never get the chance to see them and it looks as though the buttons gone blank.

I've just changed the syncing state to simply say "saving..." instead.