### PR TITLE
added draft status to the formObject model

### DIFF
--- a/api/controllers/fpr/load-form.js
+++ b/api/controllers/fpr/load-form.js
@@ -129,7 +129,7 @@ module.exports = {
         timeline: '',
         goals: '',
         other: '',
-        status: '',
+        status: 'draft',
         user: this.req.session.userId
       }).fetch();
 

--- a/assets/styles/pages/form.less
+++ b/assets/styles/pages/form.less
@@ -1,5 +1,4 @@
 #form {
-  padding: 30px;
   margin: 0 auto;
   max-width: 900px;
 

--- a/views/pages/account/fpr-form.ejs
+++ b/views/pages/account/fpr-form.ejs
@@ -1,8 +1,8 @@
 
 <div id="form" v-cloak>
 
-  <h1 v-if="formObject.status === 'pending' && !syncing.status && hidden">
-    <img :src="me.githubUserData.avatar_url" width="100" height="100">{{ me.fullName }}</h1>
+  <h1 v-if="hidden">
+  <img :src="me.githubUserData.avatar_url" width="100" height="100">{{ me.fullName }}</h1>
 
   <h3 v-html="submitMessage"></h3>
 
@@ -114,21 +114,22 @@
           <div class="form-group">
             <input type="hidden" name="status" v-model="formObject.status">
             <button class="btn btn-primary" type="button" v-if="syncing.status">... Saving ...</button>
-
-            <button
-              class="btn btn-primary"
-              type="button"
-              v-if="formObject.status === 'draft' && !syncing.status"
-              v-on:click="toggleSubmission('pending')">Submit proposal for review
-            </button>
-
-            <button
-              class="btn btn-primary"
-              type="button"
-              v-if="formObject.status === 'pending' && !syncing.status"
-              v-on:click="toggleSubmission('draft')">Withdraw proposal from review pool
-            </button>
           </div>
+
+          <button
+            class="btn btn-primary"
+            type="button"
+            v-if="formObject.status === 'draft' && !syncing.status"
+            v-on:click="toggleSubmission('pending')">Submit proposal for review
+          </button>
+
+          <button
+            class="btn btn-primary"
+            type="button"
+            v-if="formObject.status === 'pending' && !syncing.status"
+            v-on:click="toggleSubmission('draft')">Withdraw proposal from review pool
+          </button>
+
 
           <p class="text-muted" v-if="submitMessage">{{ submitMessage }}</p>
 


### PR DESCRIPTION
The button was looking for this property in the formObject and not finding it so it remained hidden.

I also changed a couple of other things:

The form's padding was making it appear too far down the page.
And the user's name was disappearing when you withdrew the proposal on the success page.